### PR TITLE
Fix broken info-diffs for groups of two packages

### DIFF
--- a/pkgdiff.pl
+++ b/pkgdiff.pl
@@ -1655,15 +1655,21 @@ sub detectChanges()
         my $N1 = $Names[0];
         my $N2 = $Names[1];
         
-        if(defined $PackageInfo{$N1}{"V2"})
-        {
-            $PackageInfo{$N2}{"V2"} = $PackageInfo{$N1}{"V2"};
-            delete($PackageInfo{$N1});
-        }
-        elsif(defined $PackageInfo{$N2}{"V2"})
-        {
-            $PackageInfo{$N1}{"V2"} = $PackageInfo{$N2}{"V2"};
-            delete($PackageInfo{$N2});
+        if(defined $PackageInfo{$N1}{"V1"}
+        and not defined $PackageInfo{$N2}{"V1"}
+        or defined $PackageInfo{$N1}{"V2"}
+        and not defined $PackageInfo{$N2}{"V2"})
+        { # definitely renamed
+            if(defined $PackageInfo{$N1}{"V2"})
+            {
+                $PackageInfo{$N2}{"V2"} = $PackageInfo{$N1}{"V2"};
+                delete($PackageInfo{$N1});
+            }
+            elsif(defined $PackageInfo{$N2}{"V2"})
+            {
+                $PackageInfo{$N1}{"V2"} = $PackageInfo{$N2}{"V2"};
+                delete($PackageInfo{$N2});
+            }
         }
     }
     


### PR DESCRIPTION
When %PackageInfo array has exactly two keys, it is assumed the package
has been renamed. That is not always the case, for example when there is
a group of two packages (same in both old and new version).
This fix prevents that by adding another contition to test if neither
package name is present in both versions simultaneously.