### PR TITLE
Strip N directory

### DIFF
--- a/pkgdiff.pl
+++ b/pkgdiff.pl
@@ -74,7 +74,7 @@ $SizeLimit, $QuickMode, $DiffWidth, $DiffLines, $Minimal, $NoWdiff,
 $IgnoreSpaceChange, $IgnoreAllSpace, $IgnoreBlankLines, $ExtraInfo,
 $CustomTmpDir, $HideUnchanged, $TargetName, $TargetTitle, %TargetVersion,
 $CompareDirs, $ListAddedRemoved, $SkipSubArchives, $LinksTarget,
-$SkipPattern, $AllText, $CheckByteCode, $FullMethodDiffs, $TrackUnchanged);
+$SkipPattern, $AllText, $CheckByteCode, $FullMethodDiffs, $TrackUnchanged, $StripDir);
 
 my $CmdName = getFilename($0);
 
@@ -148,7 +148,8 @@ GetOptions("h|help!" => \$Help,
   "links-target=s" => \$LinksTarget,
   "check-byte-code!" => \$CheckByteCode,
   "full-method-diffs!" => \$FullMethodDiffs,
-  "track-unchanged!" => \$TrackUnchanged
+  "track-unchanged!" => \$TrackUnchanged,
+  "strip-dir=s" => \$StripDir
 ) or errMsg();
 
 my $TMP_DIR = undef;
@@ -364,6 +365,9 @@ OTHER OPTIONS:
 
   -track-unchanged
       Track unchanged files in extra info.
+
+  -strip-dir NUM
+      Strip the smallest prefix containing NUM leading slashes.
 
 REPORT:
     Report will be generated to:
@@ -2959,6 +2963,11 @@ sub registerPackage(@)
     foreach my $File (sort @Files)
     {
         my $FName = cutPathPrefix($File, $CPath);
+        if ($StripDir) {
+            my @SplittedPath = split(/[\/]+/, $FName);
+            my $PrefixToRemove = join('/', @SplittedPath[0..$StripDir-1]);
+            $FName = cutPathPrefix($FName, $PrefixToRemove);
+        }
         if($PkgFormat eq "RPM"
         or $PkgFormat eq "DEB")
         { # files installed to the system


### PR DESCRIPTION
Hello,

I would like to contribute to your software by adding this feature.
With this, I'm able to strip heading folders.

As is, packages like Java JDK are not anymore detected as 100% changed.
It's related to the issue #53 and the feat is proper than what I suggested in the issue.

To use it, let's take Oracle JDK packages as example: [17.0.1-ga_to_17.0.2-ga.zip](https://github.com/lvc/pkgdiff/files/10217375/17.0.1-ga_to_17.0.2-ga.zip)