### PR TITLE
binary data breaks wdiff output

### DIFF
--- a/modules/FileType.xml
+++ b/modules/FileType.xml
@@ -3553,7 +3553,7 @@
         30
     </weight>
     <format>
-        Text
+        Binary
     </format>
 </type>
 

--- a/modules/Internals/Tools/rfcdiff-1.41-CUSTOM.sh
+++ b/modules/Internals/Tools/rfcdiff-1.41-CUSTOM.sh
@@ -317,7 +317,7 @@ function header(file1, file2) {
 "  <title>Diff: %s - %s</title> \n" \
 "  <style type=\"text/css\"> \n" \
 "    body    { font-family: Arial, sans-serif; font-size:16px; margin: 0.4ex; margin-right: auto; } \n" \
-"    table   { width: 100%; } \n" \
+"    table   { width: 100%%; } \n" \
 "    tr      { } \n" \
 "    td      { white-space: pre; font-family: Consolas, \"DejaVu Sans Mono\", \"Droid Sans Mono\", Monaco, Monospace; vertical-align: top; font-size: 0.86em;} \n" \
 "    th      { font-size: 0.86em; } \n" \


### PR DESCRIPTION
I needed to fix the %% escaping as pointed out by others.

I also have large binary data files in my RPMs and rfcdiff/wdiff attempt to diff them and fail miserably, and messes up the output, causing the tool to end up saying the binary files have not changed.  This is spite of the file size and contents changing, which is confusing to me.  Seem like there might be a better way to do a "regular" diff on the files, and if they are binary, skip all other parsing?

Changing the default DATA FileType to Binary is enough to fix it for me, but there might be a better solution that works for more people, I'm not sure.